### PR TITLE
Convert TokenValidity comments to javadoc comments

### DIFF
--- a/src/internal/TokenValidity.java
+++ b/src/internal/TokenValidity.java
@@ -10,9 +10,12 @@ import provided.TokenType;
  * @param lineNumber Token line number
  */
 public class TokenValidity {
-    private boolean valid; // Whether the token is CURRENTLY valid
-    private boolean recoverable; // Whether the token is CURRENTLY invalid but its previous state was not
-    private boolean continuable; // Whether the token can be further extended from this point
+    /** Whether the token is CURRENTLY valid */
+    private boolean valid;
+    /** Whether the token is CURRENTLY invalid but its previous state was not */
+    private boolean recoverable;
+    /** Whether the token can be further extended from this point */
+    private boolean continuable;
     private TokenType type;
     private String content;
     private String error;
@@ -28,61 +31,98 @@ public class TokenValidity {
         this.error = error;
     }
 
-    public boolean isComplete() { // The token is valid & cannot be continued from this point
+    /**
+     * Check if the token is valid & cannot be continued from this point
+     */
+    public boolean isComplete() {
         return this.valid && !this.continuable && !this.recoverable;
     }
 
-    public boolean isContinue() { // The token is currently invalid but may be valid if continued
+    /**
+     * Check if the token is currently invalid but may be valid if continued
+     */
+    public boolean isContinue() {
         return !this.valid && this.continuable && !this.recoverable;
     }
 
-    public boolean isAccepting() { // The token is currently valid & may also be continued
+    /**
+     * Check if the token is currently valid & may also be continued
+     */
+    public boolean isAccepting() {
         return this.valid && this.continuable && !this.recoverable;
     }
 
-    public boolean isReject() { // The token is invalid, but the previous state was valid
+    /**
+     * Check if the token is invalid, but the previous state was valid
+     */
+    public boolean isReject() {
         return !this.valid && this.recoverable && !this.continuable;
     }
 
-    public boolean isError() { // The token is invalid, and unrecoverably incomplete
+    /**
+     * Check if the token is invalid, and unrecoverably incomplete
+     */
+    public boolean isError() {
         return !this.valid && !this.recoverable && !this.continuable;
     }
 
-    // Helper functions to create each type of TokenValidity
+    // Helper methods to create each type of TokenValidity
+
+    /**
+     * A token that is valid, and cannot be added to
+     */
     public static TokenValidity createComplete(TokenType type, String content) {
         return new TokenValidity(type, content, true, false, false, null);
     }
 
+    /**
+     * A token that is not yet valid, but can still be added to
+     */
     public static TokenValidity createContinue(TokenType type, String content) {
         return new TokenValidity(type, content, false, false, true, null);
     }
 
+    /**
+     * A token that is valid, but can still be added to
+     */
     public static TokenValidity createAccept(TokenType type, String content) {
         return new TokenValidity(type, content, true, false, true, null);
     }
 
+    /**
+     * A token that is not valid, but can be recovered
+     */
     public static TokenValidity createReject(TokenType type, String content) {
         return new TokenValidity(type, content, false, true, false, null);
     }
 
+    /**
+     * A token that is not valid, and in a state where it cannot be recovered
+     */
     public static TokenValidity createError(String error) {
         return new TokenValidity(null, null, false, false, false, error);
     }
 
-    // Get the current error, if any
+    /**
+     * Get the current error, if any
+     */
     public String getError() {
         return this.error;
     }
 
-    // Get the token content, if any
+    /**
+     * Get the token content, if any
+     */
     public String getContent() {
         return this.content;
     }
 
-    // Creates a token from the contained content, if possible
+    /**
+     * Creates a token from the contained content, if possible
+     */
     public Token makeToken(String filename, int lineNumber) {
-        if (this.isComplete() || this.isAccepting() || this.isReject()) { // Also accept Reject here, rely on external
-                                                                          // checks to confirm/transform value
+        // Also accept Reject here, rely on external checks to confirm/transform value
+        if (this.isComplete() || this.isAccepting() || this.isReject()) {
             return new Token(this.content, filename, lineNumber, this.type);
         } else {
             return null;


### PR DESCRIPTION
Mostly as title says. Also adds doc comments to the `create*` methods

done because javadoc is nice for IDEs