### PR TITLE
Builtin functions

### DIFF
--- a/src/internal/nodes/FuncCallNode.java
+++ b/src/internal/nodes/FuncCallNode.java
@@ -7,7 +7,6 @@ import internal.ParseUnexpectedTokenException;
 import internal.PeekingArrayIterator;
 import internal.SemanticException;
 import internal.eval.Type;
-import internal.scope.DefinedFunctionSymbol;
 import internal.scope.FunctionSymbol;
 import internal.scope.Scope;
 import provided.TokenType;
@@ -62,21 +61,12 @@ public class FuncCallNode extends OperandNode {
         return List.of(this.params);
     }
 
-    public FunctionDefNode getDefinition(Scope scope) throws SemanticException {
-        FunctionSymbol calledSymbol = scope.getScope(this.name).getContext();
-        if (!calledSymbol.isBuiltin()) {
-            return ((DefinedFunctionSymbol) calledSymbol).getTarget();
-        } else {
-            // TODO(Maddy): actually handle this
-            // I think this involves changing the return type to return FunctionSymbol
-            // instead of FunctionDefNode, but I don't want to look at users of this method
-            // right now
-            throw new SemanticException("Tried to call getDefinition when calling a builtin");
-        }
+    public FunctionSymbol getDefinition(Scope scope) throws SemanticException {
+        return scope.getScope(this.name).getContext();
     }
 
     @Override
     public Type inferType(Scope scope) throws SemanticException {
-        return this.getDefinition(scope).getReturnType();
+        return this.getDefinition(scope).returnType();
     }
 }

--- a/src/internal/nodes/FuncCallNode.java
+++ b/src/internal/nodes/FuncCallNode.java
@@ -9,7 +9,6 @@ import internal.SemanticException;
 import internal.eval.Type;
 import internal.scope.DefinedFunctionSymbol;
 import internal.scope.FunctionSymbol;
-import internal.scope.LocalScope;
 import internal.scope.Scope;
 import provided.TokenType;
 
@@ -45,9 +44,9 @@ public class FuncCallNode extends OperandNode {
     @Override
     public boolean validateTree(Scope scope) {
         try {
-            LocalScope calledFunc = scope.getScope(name);
+            FunctionSymbol calledFunc = scope.getScope(name).getContext();
             return this.params.validateTree(scope)
-                    && this.params.validateParameters(scope, calledFunc.getContext());
+                    && calledFunc.validateParameters(scope, this.params);
         } catch (SemanticException e) {
             e.report(this);
             return false;

--- a/src/internal/nodes/FunctionDefNode.java
+++ b/src/internal/nodes/FunctionDefNode.java
@@ -7,7 +7,7 @@ import internal.ParseHaltException;
 import internal.PeekingArrayIterator;
 import internal.SemanticException;
 import internal.SemanticNameException;
-import internal.scope.FunctionSymbol;
+import internal.scope.DefinedFunctionSymbol;
 import internal.scope.Scope;
 import internal.eval.Type;
 import provided.TokenType;
@@ -23,7 +23,7 @@ public class FunctionDefNode extends Node {
     public FunctionBodyNode body;
 
     protected FunctionDefNode(String filename, int lineNumber, String name, List<FuncDefParamNode> params,
-                    FunctionReturnNode returnType, FunctionBodyNode body) {
+            FunctionReturnNode returnType, FunctionBodyNode body) {
         super(filename, lineNumber);
         this.name = name;
         this.params = params;
@@ -97,7 +97,7 @@ public class FunctionDefNode extends Node {
         }
 
         try {
-            scope.define(new FunctionSymbol(this.getSymbol(), getLineNumber(), this));
+            scope.define(new DefinedFunctionSymbol(this.getSymbol(), getLineNumber(), this));
             scope.enableScope(this.getSymbol());
         } catch (SemanticException e) {
             e.report(this);

--- a/src/internal/nodes/ParamsNode.java
+++ b/src/internal/nodes/ParamsNode.java
@@ -6,10 +6,6 @@ import java.util.List;
 import internal.ParseHaltException;
 import internal.ParseUnexpectedTokenException;
 import internal.PeekingArrayIterator;
-import internal.SemanticException;
-import internal.SemanticTypeException;
-import internal.SemanticUsageException;
-import internal.scope.FunctionSymbol;
 import internal.scope.Scope;
 
 public class ParamsNode extends Node {
@@ -51,32 +47,8 @@ public class ParamsNode extends Node {
         return this.params.stream().allMatch(p -> p.validateTree(scope));
     }
 
-    /**
-     * Checks if all the parameter types match
-     * 
-     * @param scope      Scope object
-     * @param definition Referenced definition
-     * @return True if good, false if no
-     */
-    public boolean validateParameters(Scope scope, FunctionSymbol definition) {
-        if (this.params.size() != definition.paramCount()) {
-            new SemanticUsageException("::" + definition.name() + "(...) requires exactly " + definition.paramCount()
-                    + " parameters, but got " + this.params.size()).report(this);
-            return false;
-        }
-        for (int p = 0; p < this.params.size(); p++) {
-            try {
-                if (this.params.get(p).inferType(scope) != definition.paramType(p)) {
-                    new SemanticTypeException(this.params.get(p).inferType(scope),
-                            definition.paramType(p)).report(this.params.get(p));
-                    return false;
-                }
-            } catch (SemanticException e) {
-                e.report(this.params.get(p));
-                return false;
-            }
-        }
-        return true;
+    public List<ExprNode> params() {
+        return this.params;
     }
 
     @Override

--- a/src/internal/nodes/ParamsNode.java
+++ b/src/internal/nodes/ParamsNode.java
@@ -9,9 +9,10 @@ import internal.PeekingArrayIterator;
 import internal.SemanticException;
 import internal.SemanticTypeException;
 import internal.SemanticUsageException;
+import internal.scope.FunctionSymbol;
 import internal.scope.Scope;
 
-public class ParamsNode extends Node{
+public class ParamsNode extends Node {
     private final ArrayList<ExprNode> params;
 
     protected ParamsNode(String filename, int lineNumber, ArrayList<ExprNode> params) {
@@ -23,7 +24,7 @@ public class ParamsNode extends Node{
     public static ParamsNode parse(PeekingArrayIterator it) throws ParseUnexpectedTokenException, ParseHaltException {
         ArrayList<ExprNode> params = new ArrayList<>();
         while (true) {
-            if(it.peekExpectSafe("]") == 0) {
+            if (it.peekExpectSafe("]") == 0) {
                 return new ParamsNode(it.getCurrentFilename(), it.getCurrentLine(), params);
             } else {
                 if (params.size() != 0) {
@@ -57,17 +58,17 @@ public class ParamsNode extends Node{
      * @param definition Referenced definition
      * @return True if good, false if no
      */
-    public boolean validateParameters(Scope scope, FunctionDefNode definition) {
-        if (this.params.size() != definition.params.size()) {
-            new SemanticUsageException("::" + definition.name + "(...) requires exactly " + definition.params.size()
+    public boolean validateParameters(Scope scope, FunctionSymbol definition) {
+        if (this.params.size() != definition.paramCount()) {
+            new SemanticUsageException("::" + definition.name() + "(...) requires exactly " + definition.paramCount()
                     + " parameters, but got " + this.params.size()).report(this);
             return false;
         }
         for (int p = 0; p < this.params.size(); p++) {
             try {
-                if (this.params.get(p).inferType(scope) != definition.params.get(0).getType().getType()) {
+                if (this.params.get(p).inferType(scope) != definition.paramType(p)) {
                     new SemanticTypeException(this.params.get(p).inferType(scope),
-                            definition.params.get(0).getType().getType()).report(this.params.get(p));
+                            definition.paramType(p)).report(this.params.get(p));
                     return false;
                 }
             } catch (SemanticException e) {
@@ -88,5 +89,5 @@ public class ParamsNode extends Node{
         children.addAll(this.params);
         return children;
     }
-    
+
 }

--- a/src/internal/scope/DefinedFunctionSymbol.java
+++ b/src/internal/scope/DefinedFunctionSymbol.java
@@ -1,0 +1,49 @@
+package internal.scope;
+
+import internal.eval.Type;
+import internal.nodes.FuncDefParamNode;
+import internal.nodes.FunctionDefNode;
+
+public class DefinedFunctionSymbol extends SymbolItem<FunctionDefNode> implements FunctionSymbol {
+    public DefinedFunctionSymbol(String symbol, int definedAt, FunctionDefNode target) {
+        super(symbol, definedAt, target);
+    }
+
+    @Override
+    public SymbolType getSymbolType() {
+        return SymbolType.Function;
+    }
+
+    @Override
+    public String name() {
+        return this.getTarget().name;
+    }
+
+    @Override
+    public int paramCount() {
+        return this.getTarget().params.size();
+    }
+
+    @Override
+    public Type paramType(int idx) {
+        FuncDefParamNode param = this.getTarget().params.get(idx);
+        if (param != null) {
+            return param.getType().getType();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean isBuiltin() {
+        return false;
+    }
+
+    @Override
+    public void execute() {
+        // TODO(phase-4)
+        // Don't know if we'll end up needing this here,
+        // but its useful for builtins if its in FuncitonSymbol
+        throw new UnsupportedOperationException("Execute not defined yet");
+    }
+}

--- a/src/internal/scope/DefinedFunctionSymbol.java
+++ b/src/internal/scope/DefinedFunctionSymbol.java
@@ -1,8 +1,12 @@
 package internal.scope;
 
+import internal.SemanticException;
+import internal.SemanticTypeException;
+import internal.SemanticUsageException;
 import internal.eval.Type;
 import internal.nodes.FuncDefParamNode;
 import internal.nodes.FunctionDefNode;
+import internal.nodes.ParamsNode;
 
 public class DefinedFunctionSymbol extends SymbolItem<FunctionDefNode> implements FunctionSymbol {
     public DefinedFunctionSymbol(String symbol, int definedAt, FunctionDefNode target) {
@@ -44,6 +48,28 @@ public class DefinedFunctionSymbol extends SymbolItem<FunctionDefNode> implement
         // TODO(phase-4)
         // Don't know if we'll end up needing this here,
         // but its useful for builtins if its in FuncitonSymbol
-        throw new UnsupportedOperationException("Execute not defined yet");
+        throw new UnsupportedOperationException("Unimplemented method 'execute'");
+    }
+
+    @Override
+    public boolean validateParameters(Scope scope, ParamsNode params) throws SemanticException {
+        if (params.params().size() != this.paramCount()) {
+            new SemanticUsageException("::" + this.name() + "(...) requires exactly " + this.paramCount()
+                    + " parameters, but got " + params.params().size()).report(params);
+            return false;
+        }
+        for (int p = 0; p < this.paramCount(); p++) {
+            try {
+                if (params.params().get(p).inferType(scope) != this.paramType(p)) {
+                    new SemanticTypeException(params.params().get(p).inferType(scope),
+                            this.paramType(p)).report(params.params().get(p));
+                    return false;
+                }
+            } catch (SemanticException e) {
+                e.report(params.params().get(p));
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/internal/scope/DefinedFunctionSymbol.java
+++ b/src/internal/scope/DefinedFunctionSymbol.java
@@ -72,4 +72,9 @@ public class DefinedFunctionSymbol extends SymbolItem<FunctionDefNode> implement
         }
         return true;
     }
+
+    @Override
+    public Type returnType() {
+        return this.getTarget().getReturnType();
+    }
 }

--- a/src/internal/scope/FunctionSymbol.java
+++ b/src/internal/scope/FunctionSymbol.java
@@ -24,6 +24,11 @@ public interface FunctionSymbol {
     public Type paramType(int idx);
 
     /**
+     * The return type of the function
+     */
+    public Type returnType();
+
+    /**
      * Whether the FunctionSymbol is a builtin or not
      * 
      * If this is false it is safe to cast to {@link DefinedFunctionSymbol}

--- a/src/internal/scope/FunctionSymbol.java
+++ b/src/internal/scope/FunctionSymbol.java
@@ -1,6 +1,8 @@
 package internal.scope;
 
+import internal.SemanticException;
 import internal.eval.Type;
+import internal.nodes.ParamsNode;
 
 public interface FunctionSymbol {
     /**
@@ -27,6 +29,15 @@ public interface FunctionSymbol {
      * If this is false it is safe to cast to {@link DefinedFunctionSymbol}
      */
     public boolean isBuiltin();
+
+    /**
+     * Checks if all the parameter types match
+     * 
+     * @param scope  The scope we're validating from
+     * @param params A ParamsNode to be used as function call parameters
+     * @return True if good, false if no
+     */
+    public boolean validateParameters(Scope scope, ParamsNode params) throws SemanticException;
 
     public void execute();
 }

--- a/src/internal/scope/FunctionSymbol.java
+++ b/src/internal/scope/FunctionSymbol.java
@@ -1,15 +1,32 @@
 package internal.scope;
 
-import internal.nodes.FunctionDefNode;
+import internal.eval.Type;
 
-public class FunctionSymbol extends SymbolItem<FunctionDefNode> {
-    public FunctionSymbol(String symbol, int definedAt, FunctionDefNode target) {
-        super(symbol, definedAt, target);
-    }
+public interface FunctionSymbol {
+    /**
+     * @return The name of the function defined by this symbol
+     */
+    public String name();
 
-    @Override
-    public SymbolType getSymbolType() {
-        return SymbolType.Function;
-    }
+    /**
+     * @return The number of parameters this function takes
+     */
+    public int paramCount();
 
+    /**
+     * Gets the type of a parameter
+     * 
+     * @param idx The index of the paramter
+     * @return The type of the parameter at idx or null if idx is out of bounds
+     */
+    public Type paramType(int idx);
+
+    /**
+     * Whether the FunctionSymbol is a builtin or not
+     * 
+     * If this is false it is safe to cast to {@link DefinedFunctionSymbol}
+     */
+    public boolean isBuiltin();
+
+    public void execute();
 }

--- a/src/internal/scope/Scope.java
+++ b/src/internal/scope/Scope.java
@@ -71,7 +71,7 @@ public class Scope {
      * @param func Function symbol
      * @throws SemanticException Thrown if the function has already been defined.
      */
-    public void define(FunctionSymbol func) throws SemanticException {
+    public void define(DefinedFunctionSymbol func) throws SemanticException {
         if (this.scopes.containsKey(func.getSymbol())) {
             throw new SemanticRedefinitionException(func.getSymbol());
         }

--- a/src/internal/scope/Scope.java
+++ b/src/internal/scope/Scope.java
@@ -5,6 +5,9 @@ import java.util.HashMap;
 import internal.SemanticException;
 import internal.SemanticRedefinitionException;
 import internal.SemanticUnknownSymbolException;
+import internal.scope.builtins.ConcatFunction;
+import internal.scope.builtins.LengthFunction;
+import internal.scope.builtins.PrintFunction;
 
 /**
  * A class representing the global scope, and containing the local scope of each
@@ -95,6 +98,26 @@ public class Scope {
 
     public Scope() {
         this.scopes = new HashMap<>();
+
+        // Include builtins
+        // don't know if we need to properly define parameters
+        // but that would require reworking LocalScope more so
+        // I'm not doing that right now unless its needed
+        FunctionSymbol print = new PrintFunction();
+        LocalScope printScope = new LocalScope(print);
+        printScope.finish();
+        this.scopes.put(print.name(), printScope);
+
+        FunctionSymbol concat = new ConcatFunction();
+        LocalScope concatScope = new LocalScope(concat);
+        concatScope.finish();
+        this.scopes.put(concat.name(), concatScope);
+
+        FunctionSymbol length = new LengthFunction();
+        LocalScope lengthScope = new LocalScope(length);
+        lengthScope.finish();
+        this.scopes.put(length.name(), lengthScope);
+
         this.currentScope = null;
     }
 

--- a/src/internal/scope/builtins/ConcatFunction.java
+++ b/src/internal/scope/builtins/ConcatFunction.java
@@ -68,4 +68,9 @@ public class ConcatFunction implements FunctionSymbol {
         throw new UnsupportedOperationException("Unimplemented method 'execute'");
     }
 
+    @Override
+    public Type returnType() {
+        return Type.String;
+    }
+
 }

--- a/src/internal/scope/builtins/ConcatFunction.java
+++ b/src/internal/scope/builtins/ConcatFunction.java
@@ -1,0 +1,71 @@
+package internal.scope.builtins;
+
+import java.util.List;
+
+import internal.SemanticException;
+import internal.SemanticTypeException;
+import internal.SemanticUsageException;
+import internal.eval.Type;
+import internal.nodes.ExprNode;
+import internal.nodes.ParamsNode;
+import internal.scope.FunctionSymbol;
+import internal.scope.Scope;
+
+public class ConcatFunction implements FunctionSymbol {
+
+    @Override
+    public String name() {
+        return "concat";
+    }
+
+    @Override
+    public int paramCount() {
+        return 2;
+    }
+
+    @Override
+    public Type paramType(int idx) {
+        if (idx < 2) {
+            return Type.String;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean isBuiltin() {
+        return true;
+    }
+
+    @Override
+    public boolean validateParameters(Scope scope, ParamsNode params) throws SemanticException {
+        List<ExprNode> p = params.params();
+
+        if (p.size() != 2) {
+            new SemanticUsageException("::" + this.name() + "(...) requires exactly " + this.paramCount()
+                    + " parameters, but got " + p.size()).report(params);
+            return false;
+        }
+
+        if (p.getFirst().inferType(scope) != Type.String) {
+            new SemanticTypeException(p.getFirst().inferType(scope),
+                    Type.String).report(p.getFirst());
+            return false;
+        }
+
+        if (p.get(1).inferType(scope) != Type.String) {
+            new SemanticTypeException(p.get(1).inferType(scope),
+                    Type.String).report(p.get(1));
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void execute() {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'execute'");
+    }
+
+}

--- a/src/internal/scope/builtins/LengthFunction.java
+++ b/src/internal/scope/builtins/LengthFunction.java
@@ -62,4 +62,9 @@ public class LengthFunction implements FunctionSymbol {
         throw new UnsupportedOperationException("Unimplemented method 'execute'");
     }
 
+    @Override
+    public Type returnType() {
+        return Type.Integer;
+    }
+
 }

--- a/src/internal/scope/builtins/LengthFunction.java
+++ b/src/internal/scope/builtins/LengthFunction.java
@@ -1,0 +1,65 @@
+package internal.scope.builtins;
+
+import java.util.List;
+
+import internal.SemanticException;
+import internal.SemanticTypeException;
+import internal.SemanticUsageException;
+import internal.eval.Type;
+import internal.nodes.ExprNode;
+import internal.nodes.ParamsNode;
+import internal.scope.FunctionSymbol;
+import internal.scope.Scope;
+
+public class LengthFunction implements FunctionSymbol {
+
+    @Override
+    public String name() {
+        return "length";
+    }
+
+    @Override
+    public int paramCount() {
+        return 1;
+    }
+
+    @Override
+    public Type paramType(int idx) {
+        if (idx == 0) {
+            return Type.String;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean isBuiltin() {
+        return true;
+    }
+
+    @Override
+    public boolean validateParameters(Scope scope, ParamsNode params) throws SemanticException {
+        List<ExprNode> p = params.params();
+
+        if (p.size() != 1) {
+            new SemanticUsageException("::" + this.name() + "(...) requires exactly " + this.paramCount()
+                    + " parameters, but got " + p.size()).report(params);
+            return false;
+        }
+
+        if (p.getFirst().inferType(scope) == Type.String) {
+            new SemanticTypeException(p.getFirst().inferType(scope),
+                    Type.String).report(p.getFirst());
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void execute() {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'execute'");
+    }
+
+}

--- a/src/internal/scope/builtins/PrintFunction.java
+++ b/src/internal/scope/builtins/PrintFunction.java
@@ -1,0 +1,61 @@
+package internal.scope.builtins;
+
+import java.util.List;
+
+import internal.SemanticException;
+import internal.SemanticTypeException;
+import internal.SemanticUsageException;
+import internal.eval.Type;
+import internal.nodes.ExprNode;
+import internal.nodes.ParamsNode;
+import internal.scope.FunctionSymbol;
+import internal.scope.Scope;
+
+public class PrintFunction implements FunctionSymbol {
+
+    @Override
+    public String name() {
+        return "print";
+    }
+
+    @Override
+    public int paramCount() {
+        return 1;
+    }
+
+    @Override
+    public Type paramType(int idx) {
+        return null;
+    }
+
+    @Override
+    public boolean isBuiltin() {
+        return true;
+    }
+
+    @Override
+    public boolean validateParameters(Scope scope, ParamsNode params) throws SemanticException {
+        List<ExprNode> p = params.params();
+
+        if (p.size() != 1) {
+            new SemanticUsageException("::" + this.name() + "(...) requires exactly " + this.paramCount()
+                    + " parameters, but got " + p.size()).report(params);
+            return false;
+        }
+
+        if (p.getFirst().inferType(scope) == Type.Void) {
+            new SemanticTypeException(p.getFirst().inferType(scope),
+                    Type.Void).report(p.getFirst());
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void execute() {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'execute'");
+    }
+
+}

--- a/src/internal/scope/builtins/PrintFunction.java
+++ b/src/internal/scope/builtins/PrintFunction.java
@@ -58,4 +58,9 @@ public class PrintFunction implements FunctionSymbol {
         throw new UnsupportedOperationException("Unimplemented method 'execute'");
     }
 
+    @Override
+    public Type returnType() {
+        return Type.Void;
+    }
+
 }


### PR DESCRIPTION
This defines all the builtin functions and adds them to global scope.

Changes:
- `FunctionSymbol` is now an interface with `DefinedFunctionSymbol` being the old implementation.
- Added `FunctionSymbol` implementations for all the builtins.
- Moved `validateParameters` into the FunctionSymbol interface instead of in `ParamsNode`.
- Created `LocalScope` objects for each builtin and added them to the `scopes` hashmap in the constructor of `Scope`, I don't think we create `Scope` anywhere yet so I don't know if this is correct or not.